### PR TITLE
Improve iOS and Mac service worker success rate

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,10 @@ Read [the guide](https://github.com/rhodey/IPFS-boot/blob/master/PIN.md) on choo
 cp example.env .env
 docker buildx build --platform=linux/amd64 -f Dockerfile.pin -t ipfs-pin .
 docker run --rm -i --platform=linux/amd64 -v ./dist:/root/dist --env-file .env ipfs-pin
-> CIDv0 = QmYVfKxUtB941bqmCwxbok1U3SRdpx77d1Du7jf5f4QGEg
-> CIDv1 = bafybeiew4pf2fndwrkh4ookhluitwtbrpg5k5tim4azftz5tao5mn344xu
-> upload: ../dist.car to s3://ipfsmike1/bafybeiew4pf2fndwrkh4ookhluitwtbrpg5k5tim4azftz5tao5mn344xu
-> done: https://bafybeiew4pf2fndwrkh4ookhluitwtbrpg5k5tim4azftz5tao5mn344xu.ipfs.dweb.link
+> CIDv0 = QmNjQKdofj3K4MzZ46c4yaAd5ZkfbxfJ3sMtFa2mPy6AfZ
+> CIDv1 = bafybeiaf2qltocemhnge427zj3a3oiopqhltucxjq23bu2paufpthkppra
+> upload: ../dist.car to s3://ipfsmike1/bafybeiaf2qltocemhnge427zj3a3oiopqhltucxjq23bu2paufpthkppra
+> done: https://bafybeiaf2qltocemhnge427zj3a3oiopqhltucxjq23bu2paufpthkppra.ipfs.dweb.link
 ```
 
 Your bootloader is now live and discoverable with v0 and v1 CIDs, see [gateways](https://ipfs.github.io/public-gateway-checker/)
@@ -60,8 +60,8 @@ Please if you want to style the default bootloader, open a PR ^.^
 
 If you clicked "boot!" without reading: you can return to boot list anytime by add #boot to the url
 
-+ react https://bafybeihpsqt6isihy3grdv2bas3n7r3dmmwjf7fgzgrgmqenovg7chxrli.ipfs.dweb.link
-+ choo https://bafybeiew4pf2fndwrkh4ookhluitwtbrpg5k5tim4azftz5tao5mn344xu.ipfs.dweb.link
++ react https://bafybeigscyx3ej2tdcp2gptw6w6e5ioc7plazsjj6apajheglp7a6udbxu.ipfs.dweb.link
++ choo https://bafybeiaf2qltocemhnge427zj3a3oiopqhltucxjq23bu2paufpthkppra.ipfs.dweb.link
 
 ## FAQ
 [FAQ](https://github.com/rhodey/IPFS-boot/blob/master/FAQ.md)

--- a/README.md
+++ b/README.md
@@ -24,10 +24,10 @@ Read [the guide](https://github.com/rhodey/IPFS-boot/blob/master/PIN.md) on choo
 cp example.env .env
 docker buildx build --platform=linux/amd64 -f Dockerfile.pin -t ipfs-pin .
 docker run --rm -i --platform=linux/amd64 -v ./dist:/root/dist --env-file .env ipfs-pin
-> CIDv0 = QmSPiciVz5pTcCj5y3KnM5xFipQfRyGRi3TmKbjPtXxvuH
-> CIDv1 = bafybeib4g7ugtpub2mlmkwuby7mzxkhgstad3kwuidoorwbi2njnl7rseq
-> upload: ../dist.car to s3://bucket-name/bafybeib4g7ugtpub2mlmkwuby7mzxkhgstad3kwuidoorwbi2njnl7rseq
-> done: https://bafybeib4g7ugtpub2mlmkwuby7mzxkhgstad3kwuidoorwbi2njnl7rseq.ipfs.dweb.link
+> CIDv0 = QmYVfKxUtB941bqmCwxbok1U3SRdpx77d1Du7jf5f4QGEg
+> CIDv1 = bafybeiew4pf2fndwrkh4ookhluitwtbrpg5k5tim4azftz5tao5mn344xu
+> upload: ../dist.car to s3://ipfsmike1/bafybeiew4pf2fndwrkh4ookhluitwtbrpg5k5tim4azftz5tao5mn344xu
+> done: https://bafybeiew4pf2fndwrkh4ookhluitwtbrpg5k5tim4azftz5tao5mn344xu.ipfs.dweb.link
 ```
 
 Your bootloader is now live and discoverable with v0 and v1 CIDs, see [gateways](https://ipfs.github.io/public-gateway-checker/)
@@ -60,8 +60,8 @@ Please if you want to style the default bootloader, open a PR ^.^
 
 If you clicked "boot!" without reading: you can return to boot list anytime by add #boot to the url
 
-+ react https://bafybeify2j3md7w75wc5gbvoogfv5tdoon63vj5xtkbn3b37n23cm5bpye.ipfs.dweb.link
-+ choo https://bafybeib4g7ugtpub2mlmkwuby7mzxkhgstad3kwuidoorwbi2njnl7rseq.ipfs.dweb.link
++ react https://bafybeihpsqt6isihy3grdv2bas3n7r3dmmwjf7fgzgrgmqenovg7chxrli.ipfs.dweb.link
++ choo https://bafybeiew4pf2fndwrkh4ookhluitwtbrpg5k5tim4azftz5tao5mn344xu.ipfs.dweb.link
 
 ## FAQ
 [FAQ](https://github.com/rhodey/IPFS-boot/blob/master/FAQ.md)

--- a/README.md
+++ b/README.md
@@ -24,10 +24,10 @@ Read [the guide](https://github.com/rhodey/IPFS-boot/blob/master/PIN.md) on choo
 cp example.env .env
 docker buildx build --platform=linux/amd64 -f Dockerfile.pin -t ipfs-pin .
 docker run --rm -i --platform=linux/amd64 -v ./dist:/root/dist --env-file .env ipfs-pin
-> CIDv0 = QmPBJnLLAksQXbbYTSk3dU7jmNd54DCe4rbT2iktMFML9J
-> CIDv1 = bafybeiamo3wzbbjvmrsrhnv3et3fati6ljw5x4xkw2dbanedodoxhqs3ju
-> upload: ../dist.car to s3://bucket-name/bafybeiamo3wzbbjvmrsrhnv3et3fati6ljw5x4xkw2dbanedodoxhqs3ju
-> done: https://bafybeiamo3wzbbjvmrsrhnv3et3fati6ljw5x4xkw2dbanedodoxhqs3ju.ipfs.dweb.link
+> CIDv0 = QmNjhis9ccMfgUsdcrF9xvEewukwwatpHVRJVErTYvkiP9
+> CIDv1 = bafybeiaf47b7rhtqxrq6eqh3w2gz3eodb3bidx23wrmsnpnxjfwqoljfga
+> upload: ../dist.car to s3://bucket-name/bafybeiaf47b7rhtqxrq6eqh3w2gz3eodb3bidx23wrmsnpnxjfwqoljfga
+> done: https://bafybeiaf47b7rhtqxrq6eqh3w2gz3eodb3bidx23wrmsnpnxjfwqoljfga.ipfs.dweb.link
 ```
 
 Your bootloader is now live and discoverable with v0 and v1 CIDs, see [gateways](https://ipfs.github.io/public-gateway-checker/)
@@ -60,8 +60,8 @@ Please if you want to style the default bootloader, open a PR ^.^
 
 If you clicked "boot!" without reading: you can return to boot list anytime by add #boot to the url
 
-+ react https://bafybeibgfkadem7gxlvpc6wmca3tuybyb6mai7zuwxix2gulhejqhlpazq.ipfs.dweb.link
-+ choo https://bafybeiamo3wzbbjvmrsrhnv3et3fati6ljw5x4xkw2dbanedodoxhqs3ju.ipfs.dweb.link
++ react https://bafybeiflu24tsng4mak5iyxl3zfolqnhll76bp5yva5m6avncuttqrt7zm.ipfs.dweb.link
++ choo https://bafybeiaf47b7rhtqxrq6eqh3w2gz3eodb3bidx23wrmsnpnxjfwqoljfga.ipfs.dweb.link
 
 ## FAQ
 [FAQ](https://github.com/rhodey/IPFS-boot/blob/master/FAQ.md)

--- a/README.md
+++ b/README.md
@@ -24,10 +24,10 @@ Read [the guide](https://github.com/rhodey/IPFS-boot/blob/master/PIN.md) on choo
 cp example.env .env
 docker buildx build --platform=linux/amd64 -f Dockerfile.pin -t ipfs-pin .
 docker run --rm -i --platform=linux/amd64 -v ./dist:/root/dist --env-file .env ipfs-pin
-> CIDv0 = QmNjhis9ccMfgUsdcrF9xvEewukwwatpHVRJVErTYvkiP9
-> CIDv1 = bafybeiaf47b7rhtqxrq6eqh3w2gz3eodb3bidx23wrmsnpnxjfwqoljfga
-> upload: ../dist.car to s3://bucket-name/bafybeiaf47b7rhtqxrq6eqh3w2gz3eodb3bidx23wrmsnpnxjfwqoljfga
-> done: https://bafybeiaf47b7rhtqxrq6eqh3w2gz3eodb3bidx23wrmsnpnxjfwqoljfga.ipfs.dweb.link
+> CIDv0 = QmSPiciVz5pTcCj5y3KnM5xFipQfRyGRi3TmKbjPtXxvuH
+> CIDv1 = bafybeib4g7ugtpub2mlmkwuby7mzxkhgstad3kwuidoorwbi2njnl7rseq
+> upload: ../dist.car to s3://bucket-name/bafybeib4g7ugtpub2mlmkwuby7mzxkhgstad3kwuidoorwbi2njnl7rseq
+> done: https://bafybeib4g7ugtpub2mlmkwuby7mzxkhgstad3kwuidoorwbi2njnl7rseq.ipfs.dweb.link
 ```
 
 Your bootloader is now live and discoverable with v0 and v1 CIDs, see [gateways](https://ipfs.github.io/public-gateway-checker/)
@@ -60,8 +60,8 @@ Please if you want to style the default bootloader, open a PR ^.^
 
 If you clicked "boot!" without reading: you can return to boot list anytime by add #boot to the url
 
-+ react https://bafybeiflu24tsng4mak5iyxl3zfolqnhll76bp5yva5m6avncuttqrt7zm.ipfs.dweb.link
-+ choo https://bafybeiaf47b7rhtqxrq6eqh3w2gz3eodb3bidx23wrmsnpnxjfwqoljfga.ipfs.dweb.link
++ react https://bafybeify2j3md7w75wc5gbvoogfv5tdoon63vj5xtkbn3b37n23cm5bpye.ipfs.dweb.link
++ choo https://bafybeib4g7ugtpub2mlmkwuby7mzxkhgstad3kwuidoorwbi2njnl7rseq.ipfs.dweb.link
 
 ## FAQ
 [FAQ](https://github.com/rhodey/IPFS-boot/blob/master/FAQ.md)

--- a/javascript/package-lock.json
+++ b/javascript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ipfs-boot",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ipfs-boot",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "license": "MIT",
       "dependencies": {
         "minimist": "^1.2.0"

--- a/javascript/package.json
+++ b/javascript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ipfs-boot",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Publish IPFS webapps which require user consent to update",
   "license": "MIT",
   "repository": {
@@ -17,8 +17,9 @@
     "postpublish": "mv README.md bin.md",
     "copy": "cp -R index.html assets dist/ && mv dist/assets/nitro_wasm* dist/ && mv dist/assets/_redirects dist/_redirects",
     "mini": "terser dist/bundle.js --compress --output dist/bundle.js",
-    "swprod": "esbuild src/sw.js --bundle --minify --outfile=dist/sw.js --define:DEV=\"false\"",
-    "swdev": "esbuild src/sw.js --bundle --outfile=dist/sw.js --define:DEV=\"true\"",
+    "export": "sed -i '$s/.*/export { getLibp2pConfig } from \\\".\\/utils\\/libp2p-defaults.js\\\"/' node_modules/@helia/verified-fetch/dist/src/index.js",
+    "swprod": "npm run export && esbuild src/sw.js --bundle --minify --outfile=dist/sw.js --define:DEV=\"false\"",
+    "swdev": "npm run export && esbuild src/sw.js --bundle --outfile=dist/sw.js --define:DEV=\"true\"",
     "build": "npm run swprod && browserify src/index.js -o dist/bundle.js && npm run mini && npm run copy",
     "dev": "npm run swdev && bhr src/index.js index.html assets/ -o dist/bundle.js"
   },

--- a/javascript/src/sw.js
+++ b/javascript/src/sw.js
@@ -35,7 +35,7 @@ const createVFetch = async (gateway, opts) => {
   opts = opts(libp2p)
   const helia = await createHelia({ libp2p, ...opts })
   return createVerifiedFetch(helia).catch((err) => {
-    return (url) => Promise.reject(new Error(`createVFetch failed ${gateway} ${err.message}`))
+    return (url) => Promise.reject(new Error(`createVFetch ${gateway} failed ${err.message}`))
   })
 }
 

--- a/javascript/src/sw.js
+++ b/javascript/src/sw.js
@@ -1,7 +1,7 @@
 import { createHelia } from 'helia'
 import { createLibp2p } from 'libp2p'
 import { trustlessGateway } from '@helia/block-brokers'
-import { httpGatewayRouting } from '@helia/routers'
+import { httpGatewayRouting, libp2pRouting } from '@helia/routers'
 import { createVerifiedFetch, getLibp2pConfig } from '@helia/verified-fetch'
 
 const cacheName = 'ipfsboot'
@@ -12,6 +12,7 @@ const cacheAssets = ['/', '/sw.js', '/bundle.js', '/assets/favicon.png', '/asset
 // dont cache bootloader files when dev server running
 const isDev = DEV === true
 
+const isIos = /iPad|iPhone|iPod/.test(self.navigator.userAgent)
 const pathGatewayRegex = /^.*\/(?<protocol>ip[fn]s)\/(?<cidOrPeerIdOrDnslink>[^/?#]*)(?<path>.*)$/
 const subdomainGatewayRegex = /^(?:https?:\/\/|\/\/)?(?<cidOrPeerIdOrDnslink>[^/]+)\.(?<protocol>ip[fn]s)\.(?<parentDomain>[^/?#]*)(?<path>.*)$/
 
@@ -46,6 +47,7 @@ fast.map((url, idx) => {
   const opts = (libp2p) => {
     const blockBrokers = [trustlessGateway()]
     const routers = [httpGatewayRouting({ gateways: [url] })]
+    !isIos && routers.unshift(libp2pRouting(libp2p))
     return { blockBrokers, routers }
   }
   createVFetch(url, opts)
@@ -58,6 +60,7 @@ maybeFast.map((url, idx) => {
   const opts = (libp2p) => {
     const blockBrokers = [trustlessGateway()]
     const routers = [httpGatewayRouting({ gateways: [url] })]
+    !isIos && routers.unshift(libp2pRouting(libp2p))
     return { blockBrokers, routers }
   }
   createVFetch(url, opts)

--- a/javascript/src/sw.js
+++ b/javascript/src/sw.js
@@ -12,7 +12,7 @@ const cacheAssets = ['/', '/sw.js', '/bundle.js', '/assets/favicon.png', '/asset
 // dont cache bootloader files when dev server running
 const isDev = DEV === true
 
-const isIos = /iPad|iPhone|iPod/.test(self.navigator.userAgent)
+const isApple = /iPhone|iPad|iPod|Macintosh/.test(navigator.userAgent)
 const pathGatewayRegex = /^.*\/(?<protocol>ip[fn]s)\/(?<cidOrPeerIdOrDnslink>[^/?#]*)(?<path>.*)$/
 const subdomainGatewayRegex = /^(?:https?:\/\/|\/\/)?(?<cidOrPeerIdOrDnslink>[^/]+)\.(?<protocol>ip[fn]s)\.(?<parentDomain>[^/?#]*)(?<path>.*)$/
 
@@ -47,7 +47,7 @@ fast.map((url, idx) => {
   const opts = (libp2p) => {
     const blockBrokers = [trustlessGateway()]
     const routers = [httpGatewayRouting({ gateways: [url] })]
-    !isIos && routers.unshift(libp2pRouting(libp2p))
+    !isApple && routers.unshift(libp2pRouting(libp2p))
     return { blockBrokers, routers }
   }
   createVFetch(url, opts)
@@ -60,7 +60,7 @@ maybeFast.map((url, idx) => {
   const opts = (libp2p) => {
     const blockBrokers = [trustlessGateway()]
     const routers = [httpGatewayRouting({ gateways: [url] })]
-    !isIos && routers.unshift(libp2pRouting(libp2p))
+    !isApple && routers.unshift(libp2pRouting(libp2p))
     return { blockBrokers, routers }
   }
   createVFetch(url, opts)

--- a/javascript/src/sw.js
+++ b/javascript/src/sw.js
@@ -1,5 +1,8 @@
+import { createHelia } from 'helia'
+import { createLibp2p } from 'libp2p'
+import { trustlessGateway } from '@helia/block-brokers'
 import { httpGatewayRouting } from '@helia/routers'
-import { createVerifiedFetch } from '@helia/verified-fetch'
+import { createVerifiedFetch, getLibp2pConfig } from '@helia/verified-fetch'
 
 const cacheName = 'ipfsboot'
 
@@ -26,18 +29,38 @@ self.addEventListener('activate', (event) => {
   event.waitUntil(self.clients.claim())
 })
 
+const createVFetch = async (gateway, opts) => {
+  const libp2pConf = getLibp2pConfig()
+  const libp2p = await createLibp2p(libp2pConf)
+  opts = opts(libp2p)
+  const helia = await createHelia({ libp2p, ...opts })
+  return createVerifiedFetch(helia).catch((err) => {
+    return (url) => Promise.reject(new Error(`createVFetch failed ${gateway} ${err.message}`))
+  })
+}
+
 // todo: replace with your cloudflare bucket (or worker)
-// todo: if no cloudflare bucket replace with empty array
+// todo: if no cloudflare replace with empty array
 const fast = ['https://ipfs.lock.host']
 fast.map((url, idx) => {
-  createVerifiedFetch({ gateways: [url], routers: [] })
+  const opts = (libp2p) => {
+    const blockBrokers = [trustlessGateway()]
+    const routers = [httpGatewayRouting({ gateways: [url] })]
+    return { blockBrokers, routers }
+  }
+  createVFetch(url, opts)
     .then((vfetch) => fast[idx] = vfetch)
 })
 
 // public gateways as fallbacks
 const maybeFast = ['https://trustless-gateway.link', 'https://dweb.link']
 maybeFast.map((url, idx) => {
-  createVerifiedFetch({ gateways: [url], routers: [] })
+  const opts = (libp2p) => {
+    const blockBrokers = [trustlessGateway()]
+    const routers = [httpGatewayRouting({ gateways: [url] })]
+    return { blockBrokers, routers }
+  }
+  createVFetch(url, opts)
     .then((vfetch) => maybeFast[idx] = vfetch)
 })
 
@@ -45,25 +68,15 @@ maybeFast.map((url, idx) => {
 const verifiedFetchMulti = (url) => {
   const okOr404 = (res) => {
     if (res.ok || res.status === 404) { return res }
-    return Promise.reject(res)
+    return Promise.reject(new Error('status ' + res?.status))
   }
-  let aborts = []
-  const go = (vfetch) => {
-    const ctrl = new AbortController()
-    aborts.push(ctrl)
-    const abort = () => {
-      // aborts.filter((c) => c !== ctrl).forEach((c) => c.abort()) // avoid issue with verified fetch
-      aborts = []
-    }
-    const { signal } = ctrl
-    return vfetch(url, { signal }).then(okOr404).then((ok) => {
-      abort()
-      return ok
-    })
-  }
+  const go = (vfetch) => vfetch(url).then(okOr404)
   const idx = Math.floor(Math.random() * maybeFast.length)
   const gateways = [...fast, maybeFast[idx]]
-  return Promise.any(gateways.map(go))
+  return Promise.any(gateways.map(go)).catch((err) => {
+    err.message = err.errors.map((e) => e.message).join(', ')
+    return Promise.reject(err)
+  })
 }
 
 const putInCache = async (req, res) => {
@@ -78,7 +91,7 @@ const cacheFirst = async (req, event, gateway) => {
   if (gateway) {
     const { protocol, cidOrPeerIdOrDnslink: cid, path } = gateway
     console.log('sw intercept', protocol, cid, path)
-    url = `${protocol}://${cid}/${path}`
+    url = `${protocol}://${cid}${path}`
   }
   const fn = gateway ? verifiedFetchMulti : fetch
   const ok = await fn(url)


### PR DESCRIPTION
Improve iOS and Mac service worker success rate

Removes libp2pRouting from codepath if userAgent is iOS or Mac

[verifiedFetch](https://github.com/ipfs/helia-verified-fetch) is turning out to be a bit unreliable

Opened #6 